### PR TITLE
Re-build v0.8.8 with OpenMM 7.6+ pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . -vv --no-deps"
 
 requirements:
@@ -28,7 +28,7 @@ requirements:
     - numpy >=1.14
     - numpydoc
     - scipy
-    - openmm >=7.0.1, <=7.5.1
+    - openmm >=7.6
     - ambertools >=19
     - pytables
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - numpy >=1.14
     - numpydoc
     - scipy
-    - openmm >=7.6
+    - openmm
     - ambertools >=19
     - pytables
 


### PR DESCRIPTION
See https://github.com/conda-forge/openmoltools-feedstock/pull/1#issuecomment-923990581

Some of our tests that depend on Yank are failing due to v0.8.7 getting pulled down. I think this should fix that.

This pin doesn't really do much - it may be best to just un-pin it, depending on the plans to support each import path.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
